### PR TITLE
include SubjectEmailMap ...

### DIFF
--- a/geoevents/feedback/views.py
+++ b/geoevents/feedback/views.py
@@ -9,7 +9,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import redirect, get_object_or_404
 from geoevents.core.views import PageHeaderMixin, MessagesModelFormMixin
 from geoevents.feedback.forms import ArticleForm, FeedbackForm
-from geoevents.feedback.models import Category, Article
+from geoevents.feedback.models import Category, Article, SubjectEmailMap
 from geoevents.operations.views import FormParametersFromGetParamsMixin
 
 


### PR DESCRIPTION
How did work before?

The following error occurs when a user trys to submit feedback: Traceback (most recent call last):

 File "/ozone/django-test/lib/python2.6/site-packages/django/core/handlers/base.py", line 115, in get_response
   response = callback(request, _callback_args, *_callback_kwargs)

 File "/ozone/django-test/lib/python2.6/site-packages/django/views/generic/base.py", line 68, in view
   return self.dispatch(request, _args, *_kwargs)

 File "/ozone/django-test/lib/python2.6/site-packages/django/views/generic/base.py", line 86, in dispatch
   return handler(request, _args, *_kwargs)

 File "/ozone/django-test/lib/python2.6/site-packages/django/views/generic/edit.py", line 199, in post
   return super(BaseCreateView, self).post(request, _args, *_kwargs)

 File "/ozone/django-test/lib/python2.6/site-packages/django/views/generic/edit.py", line 165, in post
   return self.form_valid(form)

 File "/ozone/django/django/r3/feedback/views.py", line 74, in form_valid
   self.send_email()

 File "/ozone/django/django/r3/feedback/views.py", line 50, in send_email
   except SubjectEmailMap.DoesNotExist: # this subject hasn't been defined yet

NameError: global name 'SubjectEmailMap' is not defined
